### PR TITLE
MACアドレスの指定を変更するAPIサーバの追加

### DIFF
--- a/packet_capture/README.md
+++ b/packet_capture/README.md
@@ -11,3 +11,14 @@ module.exports = {
     'mac': mac
 } 
 ```
+
+## ターゲットにするMACアドレスの変更方法
+ターゲットにするMACアドレスの変更は，HTTP APIサーバを通じて行う．
+
+`main.js`を実行することでAPIサーバが起動し，`/`の`8080`に以下のJSONでPOSTリクエストを送ることで変更することができる．
+
+```js
+{
+  'macAddr'[xx,xx,xx,xx,xx,xx]
+}
+```

--- a/packet_capture/main.js
+++ b/packet_capture/main.js
@@ -3,11 +3,12 @@ let http = require('http')
 
 //MACアドレスを他ファイルからimport
 const MACADDR = require('./macAddr.js')
+const PORT = 8080
 
 
 let tcp_tracker = new pcap.TCPTracker()
-let pcap_session = pcap.createSession('wlan0', "arp")
-
+//let pcap_session = pcap.createSession('wlan0', "arp")
+let pcap_session = pcap.createSession('en0','arp')
 let server = http.createServer()
 
 // ここにターゲットにするデバイスのMACアドレス
@@ -36,20 +37,34 @@ pcap_session.on('packet', function (raw_packet) {
   }
 })
 
+console.log('HTTP Server Start')
+console.log("Listen ",PORT)
 server.on('request',setMacAddr)
-server.listen(8080)
+server.listen(PORT)
 
 // MacAddrの変更を行う
 function setMacAddr(req,res) {
   
+  // POST以外の場合　エラーメッセージを送信
   if(req.method != 'POST') {
+    errRsp = JSON.stringify({
+      "type" : "Method Error",
+      "message" : "Only post request"
+    })
+    res.write(errRsp)
     res.end()
     return
   }
 
+  // 監視対象のMACアドレスの変更
   req.on('data',(chunk) => {
     let reqData = JSON.parse(chunk)
     targetMacAddr = reqData['macAddr']
+    let successRsp = JSON.stringify({
+      "type" : "Success",
+      "message" : "Target MACAddress Changed!"
+    })
+    res.write(successRsp)
     res.end()
   })
 }

--- a/packet_capture/main.js
+++ b/packet_capture/main.js
@@ -7,8 +7,7 @@ const PORT = 8080
 
 
 let tcp_tracker = new pcap.TCPTracker()
-//let pcap_session = pcap.createSession('wlan0', "arp")
-let pcap_session = pcap.createSession('en0','arp')
+let pcap_session = pcap.createSession('wlan0', "arp")
 let server = http.createServer()
 
 // ここにターゲットにするデバイスのMACアドレス


### PR DESCRIPTION
 使用方法については同ディレクトリの[README.md](https://github.com/yagijin/hack_u2019nagoya/tree/master/packet_capture)にまとめました．