### PR TITLE
 LAN上に接続されているMACアドレスを取得できるように変更

### DIFF
--- a/packet_capture/arper.js
+++ b/packet_capture/arper.js
@@ -1,0 +1,47 @@
+function Macvendor(_macadd, _vendor) { //MACアドレスとベンダー名を保存するためのコンストラクタ
+  this.macadd = _macadd;
+  this.vendor = _vendor;
+}
+
+function calcMacAddrs (){
+  return new Promise((resolve,reject) => {
+    var exec = require('child_process').exec; //Node jsでコマンドを実行するために必要
+    var COMMAND = 'sudo arp-scan -l'; //実行するコマンド(あらかじめ「sudo install arp-scan」でarp-scanをインストールする必要がある)
+    var result = []; //コマンド実行結果の切り出し時に使用
+    var hoge = []; //resultで切り出した行を更に細分化する際に使用
+    var addven = []; //MACアドレスとベンダー名を格納するために使用
+    
+    exec(COMMAND, function (error, stdout, stderr) {
+    
+      //Error表示
+      if (error !== null) {
+        console.log('Error: arper.js');
+        return;
+      }
+    
+      /*  'sudo arp-scan -l'の実行結果を見たい場合
+       console.log('stdout: ', stdout);
+      */
+    
+      result = stdout.split("\n"); //出力結果から該当する行のみ切り出す
+    
+      for (var i = 2; i < result.length - 4; i++) { //最初の2行目と最後の4行目以外を使用
+        hoge = result[i].split("\t"); //IPアドレス,MACアドレス,ベンダー名を分別
+        addven[i - 2] = new Macvendor(hoge[1], hoge[2]); //hoge[1]がMACアドレス,hoge[2]がベンダー名
+      }
+    
+      /*  addvenのMACアドレスとベンダー名が見たい場合
+     for(var j = 0; j < addven.length; j++){
+         console.log(addven[j].macadd, ":", addven[j].vendor);
+     }
+     */
+      resolve(addven);
+    }
+    );
+  })
+}
+
+
+module.exports = {
+  calcMacAddrs: calcMacAddrs
+};

--- a/packet_capture/main.js
+++ b/packet_capture/main.js
@@ -1,31 +1,14 @@
-let pcap = require('pcap')
-let express = require('express')
-let { Expo } = require('expo-server-sdk')
+const pcap = require('pcap')
+const express = require('express')
 
-let util = require('./util.js')
-let arper = require('./arper.js')
+const util = require('./util.js')
+const arper = require('./arper.js')
 
 //MACアドレスを他ファイルからimport
 const MACADDR = require('./macAddr.js')
 
-
 const PORT = 8080
 const NET_INTERFACE = 'en0'
-
-let expo = new Expo()
-
-// Packet Caputure
-let tcp_tracker = new pcap.TCPTracker()
-let pcap_session = pcap.createSession(NET_INTERFACE, "arp")
-
-// HTTP Server
-let app = express()
-app.listen(PORT)
-
-app.use(express.urlencoded({
-  extended: true
-}))
-app.use(express.json())
 
 // ここにターゲットにするデバイスのMACアドレス
 let targetMacAddr = MACADDR.mac();
@@ -33,6 +16,20 @@ let targetMacAddr = MACADDR.mac();
 let deviceToken = 'Default'
 let startFlag = false
 let notifyType = 'Default'
+
+// Packet Caputure
+let pcapSession = pcap.createSession(NET_INTERFACE, "arp")
+
+// HTTP Server
+let app = express()
+
+
+app.listen(PORT)
+app.use(express.urlencoded({
+  extended: true
+}))
+app.use(express.json())
+
 
 /**
  * 配列の内容が同一であるかの判定を行う
@@ -47,7 +44,7 @@ function compareArray(arr) {
   return true
 }
 
-pcap_session.on('packet', function (raw_packet) {
+pcapSession.on('packet', function (raw_packet) {
   let packet = pcap.decode.packet(raw_packet);
   let sourceMacAddr = packet["payload"]["shost"]["addr"]
 
@@ -63,6 +60,7 @@ pcap_session.on('packet', function (raw_packet) {
   }
 })
 
+// MACアドレスの一覧を取得
 app.get('/get_mac_list',function(req,res){
   (async () => {
     let resultMacAddrs = await arper.calcMacAddrs()
@@ -73,6 +71,7 @@ app.get('/get_mac_list',function(req,res){
   })()
 })
 
+// 監視の開始
 app.post('/monitor', function(req,res){
   console.log(req.body)
   if(req.body.token === undefined || req.body.macAddr === undefined || req.body.notifyType === undefined ) {

--- a/packet_capture/main.js
+++ b/packet_capture/main.js
@@ -3,13 +3,14 @@ let express = require('express')
 let { Expo } = require('expo-server-sdk')
 
 let util = require('./util.js')
+let arper = require('./arper.js')
 
 //MACアドレスを他ファイルからimport
 const MACADDR = require('./macAddr.js')
 
 
 const PORT = 8080
-const NET_INTERFACE = 'wlan0'
+const NET_INTERFACE = 'en0'
 
 let expo = new Expo()
 
@@ -64,9 +65,10 @@ pcap_session.on('packet', function (raw_packet) {
 
 app.get('/get_mac_list',function(req,res){
   (async () => {
-    await util.sleep(1000)
+    let resultMacAddrs = await arper.calcMacAddrs()
+
     res.json({
-      'macAddrs':util.createMacAddrList()
+      'macAddrs': resultMacAddrs
     })
   })()
 })


### PR DESCRIPTION
@YugaWatanabe  が加えた変更を適用
`/get_mac_list`にGETリクエストを飛ばした際の挙動を変更(実行には管理者権限が必要です．)
デモ用で使うときには，念の為デモ機のMACアドレスを確実に返すように仕込んでも良いかもしれません．